### PR TITLE
fix(consoleErrors): removing unnecessary 'cause' property on plugin errors, as it causes build failures

### DIFF
--- a/src/core/errors/consoleErrors.ts
+++ b/src/core/errors/consoleErrors.ts
@@ -1,9 +1,8 @@
 class PluginError extends Error {
-  constructor(message: string, cause?: string) {
+  constructor(message: string) {
     super(message)
     this.name = "PAYLOAD_AUTH_PLUGIN_ERROR"
     this.message = message
-    this.cause = cause
     this.stack = ""
   }
 }


### PR DESCRIPTION
Closes #90